### PR TITLE
Always use a slash when joining paths

### DIFF
--- a/src/tools/io.clj
+++ b/src/tools/io.clj
@@ -24,6 +24,18 @@
     (.substring s (count prefix))
     s))
 
+(defn- rstrip
+  [^String s ^String suffix]
+  (if (str/ends-with? s suffix)
+    (.substring s 0 (- (count s) (count suffix)))
+    s))
+
+(defn- strip
+  [^String s ^String trim]
+  (-> s
+      (lstrip trim)
+      (rstrip trim)))
+
 (defn strip-bom
   "Remove the BOM on a string if necessary.
    See https://en.wikipedia.org/wiki/Byte_order_mark"
@@ -60,8 +72,8 @@
     :post [(string? %)]}
    (let [[prefix x] (split-protocol x)
          is-root (str/starts-with? x "/")
-         parts (map (fn [part] (lstrip part "/")) (cons x xs))
-         path (str (when is-root "/") (apply io/file parts))]
+         parts (map (fn [part] (strip part "/")) (cons x xs))
+         path (str (when is-root "/") (str/join "/" (map io/file parts)))]
 
      (join-protocol prefix path))))
 

--- a/test/tools/io/test.clj
+++ b/test/tools/io/test.clj
@@ -27,6 +27,8 @@
   (is (= "/foo/bar" (tio/join-path "/foo/" "bar")))
   (is (= "gs://bar/a/b/c" (tio/join-path "gs://bar" "a" "b" "c")))
 
+  (is (= "a/../b" (tio/join-path "a" ".." "b")))
+
   (is (thrown? AssertionError (tio/join-path nil)))
   (is (thrown? AssertionError (tio/join-path "gs://" "foo" nil "bar"))))
 


### PR DESCRIPTION
Should fix #1. This uses `clojure.string/join "/"` to join the paths instead of relying on the user’s filesystem Java class.