### PR TITLE
Load config file from any protocol

### DIFF
--- a/src/tools/io.clj
+++ b/src/tools/io.clj
@@ -328,9 +328,12 @@
     (instance? File filename) (.getPath ^File filename)
     :else (str filename)))
 
+(defn- fail-as-nil [f] (try (f) (catch Exception _ nil)))
+
 (defn load-config-file
   "read and parse a configuration file
-   edn, clj, json, js, yaml, yml supported"
+   edn, clj, json, js, yaml, yml supported
+   protocols supported are those of `tools.io.core/file-reader`"
   {:added "0.3.16"}
   ([filename]
    (when (some? filename)
@@ -339,9 +342,10 @@
            parse-fn (get config-parser (or (ext config-exts-equivalence) ext))]
        (load-config-file filename parse-fn))))
   ([filename parser]
+   {:pre [parser]}
     (let [path     (->file-path filename)
-          file     (as-file! filename)
-          raw      (try (slurp file) (catch Exception _ nil))]
+          raw      (or (fail-as-nil #(slurp filename))
+                       (fail-as-nil #(-> filename as-file! slurp))) ]
       (when raw
         (try
           (parser raw)

--- a/test/tools/io/test.clj
+++ b/test/tools/io/test.clj
@@ -95,11 +95,14 @@
 
 (deftest load-config-files
   (testing "reading resource test.edn file"
-    (is (nil? (tio/load-config-file "not-exists")))
+    (is (nil? (tio/load-config-file "not-exists.edn")))
+    (is (thrown? AssertionError (tio/load-config-file "what-s-in-the-box?")) "unknown parser")
     (is (= 42 (:answer (tio/load-config-file (io/resource "test.edn")))) "load resource")
     (is (= 84 (:answer (tio/load-config-file (io/resource "test-with-reader-tag.edn") custom-edn-read))) "load resource with custom parser")
     (is (= 42 (:answer (tio/load-config-file "test.yml"))) "load filename as resource")
-    (is (= 42 (:answer (tio/load-config-file "test-resources/test.json"))) "load absolute filename")))
+    (is (= 42 (:answer (tio/load-config-file "test-resources/test.json"))) "load absolute filename")
+    (with-in-str "{:answer 42}"
+     (is (= 42 (:answer (tio/load-config-file *in* edn/read-string))) "load from stdin (protocol independant)"))))
 
 (deftest read-txt
   (testing "reading resource test.txt file"


### PR DESCRIPTION
Before, only local files could be loaded as configuration files.
Now, one can use any protocol to load config files from.