### PR TITLE
mk-file-protocol-checker: ignore files with no protocol

### DIFF
--- a/src/tools/io.clj
+++ b/src/tools/io.clj
@@ -123,7 +123,7 @@
 
 (defn line-write
   "Write one line in a file created with tools.io.core/file-writer. It is the
-   caller's responsability to close the file using tools.io.core/close! when
+   caller's responsibility to close the file using tools.io.core/close! when
    it’s done."
   {:added "0.3.16"}
   [{:keys [^BufferedWriter stream] :as _file} line]
@@ -142,7 +142,7 @@
       (core/close! file))))
 
 (def ^{:doc "Alias of tools.io.core/list-files for backward compatibility."
-       :arglists '([path & [options]])} list-files tools.io.core/list-files)
+       :arglists '([path & [options]])} list-files core/list-files)
 
 (defn read-string-format-file-fn
   "Builder for a file-reader function."

--- a/src/tools/io/core.clj
+++ b/src/tools/io/core.clj
@@ -47,13 +47,12 @@
   {:pre [(set? protocols)]}
   (fn [filename]
     (when-not (instance? Reader filename)
-      (let [filename (str filename)]
-        (or (not (str/includes? filename "://"))
-            (-> filename
-                (str/split #"://" 2)
-                first
-                str/lower-case
-                protocols))))))
+      (-> filename
+          str
+          (str/split #"://" 2)
+          first
+          str/lower-case
+          protocols))))
 
 (defmulti mk-input-stream
   "Returns an input stream with any implementation."
@@ -136,7 +135,13 @@
 ;; -------------
 
 (register-file-pred!
-  :base (mk-file-protocol-checker #{"file" ""}))
+  :base (some-fn
+          (mk-file-protocol-checker #{"file"})
+          (fn filename-with-no-protocol?
+            [filename]
+            (and
+              (not (instance? Reader filename))
+              (not (str/includes? (str filename) "://"))))))
 
 (defmethod mk-input-stream :base
   [filename & [options]]

--- a/src/tools/io/core.clj
+++ b/src/tools/io/core.clj
@@ -46,7 +46,7 @@
   [protocols]
   {:pre [(set? protocols)]}
   (fn [filename]
-    (when-not (instance? java.io.Reader filename)
+    (when-not (instance? Reader filename)
       (let [filename (str filename)]
         (or (not (str/includes? filename "://"))
             (-> filename

--- a/test/tools/io/test.clj
+++ b/test/tools/io/test.clj
@@ -185,6 +185,17 @@
        (finally
           (cio/unregister-file-pred! file-type)))))
 
+(deftest mk-file-protocol-checker
+  (let [checker (#'cio/mk-file-protocol-checker #{"foo" "bar"})]
+    (are [ok-path] (checker ok-path)
+                   "foo://something"
+                   "bar://something"
+                   "FOO://something")
+    (are [not-ok-path] (not (checker not-ok-path))
+                       "http://something"
+                       "/home/linus/SECRET"
+                       "hello")))
+
 (deftest read-from-stdin
   (with-in-str "{\"toto\": 42}"
     (is (= [{:toto 42}]


### PR DESCRIPTION
(This is an issue we noticed with @patinside while reviewing the code)

Right now the predicate *always* returns true if given a filename with no protocol, even if the protocols set it was created doesn’t include an empty string:

```clojure
((mk-file-protocol-checker #{"ftp"}) "/home/baptiste/dirty-oscaro-secrets.txt")
;; => true
```

This means the HTTP(S) file type checker accept any filename with no protocol. In practice we don’t see the issue because the `:base` checker is ran before the `:http` one.

This PR extracts the “filename has no protocol” check off the `mk-protocol-checker` function. The only breaking change is that the `:base` checker no longer support filenames starting with `://` (with no protocol before) but I think that’s better.